### PR TITLE
Update compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-DSP = "0.5.2"
-FFTW = "0.2.4"
-SpecialFunctions = "0.7.2"
+DSP = "0.5.2,0.6"
+FFTW = "0.2.4,1"
+SpecialFunctions = "0.7.2,0.8"
 julia = "1"


### PR DESCRIPTION
Using old version of DSP and FFTW gives me 

```julia
WARNING: both AbstractFFTs and Util export "Frequencies"; uses of it in module Periodograms must be qualified
ERROR: LoadError: LoadError: UndefVarError: Frequencies not defined
...
```

So I updated the dependencies to their recent release.