### PR TITLE
Correct type for arg()

### DIFF
--- a/src/wrap.jl
+++ b/src/wrap.jl
@@ -380,7 +380,7 @@ function abs(_in::AFArray{T,N}) where {T,N}
     AFArray{T,N}(out[])
 end
 
-function arg(_in::AFArray{T,N}) where {T,N}
+function arg(_in::AFArray{Complex{T},N}) where {T,N}
     out = RefValue{af_array}(0)
     _error(ccall((:af_arg,af_lib),af_err,(Ptr{af_array},af_array),out,_in.arr))
     AFArray{T,N}(out[])


### PR DESCRIPTION
af_arg() computes the phase of an array of complex values and returns an array of real angles.
As currently written, arg() throws an error when attempting to convert the returned real array
to the type of the given complex AFArray.

Minimum working example:
```
using ArrayFire
arg(rand(AFArray{ComplexF32}, 1, 1))
```
